### PR TITLE
Added possibility to use full particles options object

### DIFF
--- a/src/vue-particles/vue-particles.vue
+++ b/src/vue-particles/vue-particles.vue
@@ -16,6 +16,7 @@
     :hoverMode="hoverMode"
     :clickEffect="clickEffect"
     :clickMode="clickMode"
+    :particlesData="particlesData"
   ></div>
 </template>
 <script>
@@ -82,6 +83,10 @@
       clickMode: {
         type: String,
         default: 'push'
+      },
+      particlesData: {
+        type: Object,
+        default: null
       }
     },
     mounted () {
@@ -103,7 +108,8 @@
           this.hoverEffect,
           this.hoverMode,
           this.clickEffect,
-          this.clickMode
+          this.clickMode,
+          this.particlesData
         )
       })
     },
@@ -123,8 +129,10 @@
         hoverEffect,
         hoverMode,
         clickEffect,
-        clickMode
+        clickMode,
+        particlesData
       ) {
+        if( particlesData === null ){
         particlesJS('particles-js', {
           "particles": {
             "number": {
@@ -237,6 +245,9 @@
           },
           "retina_detect": true
         });
+        } else {
+          particlesJS('particles-js', particlesData );
+        }
       }
 
     }


### PR DESCRIPTION
I had a full config object with customized options, that I wanted to use.
Since these options didn't fit into all the defaults in this module, I wanted to pass in my object to override all other parameters. 
This works for me, and solved my needs.

It is used like this:
`
<vue-particles :particlesData="particlesSetup"></vue-particles>
`