### PR TITLE
Added support for multiple particles on a single page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,7 +144,7 @@
     text-align: center;
   }
 
-  #particles-js {
+  .particles-js {
     background-image: url("./assets/sky.jpg");
     background-size: cover;
     position: absolute;

--- a/src/vue-particles/vue-particles.vue
+++ b/src/vue-particles/vue-particles.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    id="particles-js"
+    class="particles-js"
+    :id="id"
     :color="color"
     :particleOpacity="particleOpacity"
     :linesColor="linesColor"
@@ -22,6 +23,11 @@
   /* eslint-disable */
   export default {
     name: 'vue-particles',
+    data: function () {
+      return {
+        id: 'particles-instance-' + Math.floor(Math.random() * 5000)
+      }
+    },
     props: {
       color: {
         type: String,
@@ -125,7 +131,7 @@
         clickEffect,
         clickMode
       ) {
-        particlesJS('particles-js', {
+        particlesJS(this.id, {
           "particles": {
             "number": {
               "value": particlesNumber,


### PR DESCRIPTION
For a client project the client wanted 2 instances of particles on either side of a page with different colors. I realized that this was not possible with the way vue-particles was currently configured. 

To make it possible I made it so that the ID for the root element is a reactive Vue data property with a randomly generated number at the end. This way there can be several instances on the page without them clashing. 