### PR TITLE
Adding ability to pass in shape options as a paramater to further configure the size and shape of individual particles, even passing in images!

### DIFF
--- a/src/vue-particles/vue-particles.vue
+++ b/src/vue-particles/vue-particles.vue
@@ -7,6 +7,7 @@
     :linesColor="linesColor"
     :particlesNumber="particlesNumber"
     :shapeType="shapeType"
+    :shapeOptions="shapeOptions"
     :particleSize="particleSize"
     :linesWidth="linesWidth"
     :lineLinked="lineLinked"
@@ -44,6 +45,10 @@
       shapeType: {
         type: String,
         default: 'circle'
+      },
+      shapeOptions: {
+        type: Object,
+        default: {}
       },
       particleSize: {
         type: Number,
@@ -99,6 +104,7 @@
           this.particleOpacity,
           this.particlesNumber,
           this.shapeType,
+          this.shapeOptions,
           this.particleSize,
           this.linesColor,
           this.linesWidth,
@@ -119,6 +125,7 @@
         particleOpacity,
         particlesNumber,
         shapeType,
+        shapeOptions,
         particleSize,
         linesColor,
         linesWidth,
@@ -152,7 +159,8 @@
               },
               "polygon": {
                 "nb_sides": 5
-              }
+              },
+              ...shapeOptions
             },
             "opacity": {
               "value": particleOpacity,


### PR DESCRIPTION
The only issue I've had so far is when I build the project, it appears to throw an UglifyJS error. I'm guessing maybe the spread operator isn't supported? Here's an example using the new options prop:

```vue
<vue-particles 
    shapeType="image" 
    :shapeOptions="{
          image: {
            src: 'static/heart.png',
            width: 40,
            height: 40
          }
        }"
    color="#d33838" :lineLinked="false"/>
```

![image](https://user-images.githubusercontent.com/12945799/45853990-987c1900-bd16-11e8-82de-ee97684936e9.png)
