### PR TITLE
Add 'move' option to vue component.

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -134,6 +134,14 @@ Vue.use(VueParticles)
           </td>
         </tr>
         <tr>
+          <td data-th="Name">move</td>
+          <td data-th="Type">Boolean</td>
+          <td data-th="Default">true</td>
+          <td data-th="Description">
+            Particles movement
+          </td>
+        </tr>
+        <tr>
           <td data-th="Name">moveSpeed</td>
           <td data-th="Type">Number</td>
           <td data-th="Default">3</td>

--- a/src/vue-particles/vue-particles.vue
+++ b/src/vue-particles/vue-particles.vue
@@ -12,6 +12,7 @@
     :lineLinked="lineLinked"
     :lineOpacity="lineOpacity"
     :linesDistance="linesDistance"
+    :move="move"
     :moveSpeed="moveSpeed"
     :hoverEffect="hoverEffect"
     :hoverMode="hoverMode"
@@ -69,6 +70,10 @@
         type: Number,
         default: 150
       },
+      move: {
+        type: Boolean,
+        default: true
+      },
       moveSpeed: {
         type: Number,
         default: 3
@@ -105,6 +110,7 @@
           this.lineLinked,
           this.lineOpacity,
           this.linesDistance,
+          this.move,
           this.moveSpeed,
           this.hoverEffect,
           this.hoverMode,
@@ -125,6 +131,7 @@
         lineLinked,
         lineOpacity,
         linesDistance,
+        move,
         moveSpeed,
         hoverEffect,
         hoverMode,
@@ -182,7 +189,7 @@
               "width": linesWidth
             },
             "move": {
-              "enable": true,
+              "enable": move,
               "speed": moveSpeed,
               "direction": "none",
               "random": false,


### PR DESCRIPTION
I would like to add an option to define the particles.js move option. This would let you use vue-particles to create a static background that doesn't use any CPU/GPU after the initial render. I tested setting the moveSpeed option to zero but this still uses CPU/GPU (Chrome, Windows 10).