### PR TITLE
fix: IE11 + SCRIPT1003: Expected ‘:’ error

### DIFF
--- a/src/vue-particles/index.js
+++ b/src/vue-particles/index.js
@@ -3,7 +3,7 @@ import particles from './vue-particles.vue'
 
 const VueParticles = {
 
-    install (Vue, options) {
+    install: function(Vue, options) {
         Vue.component('vue-particles', particles)
     }
 


### PR DESCRIPTION
IE11 doesn’t support the method definition shorthand. 
Need to change syntax for make it compatible and use babel configuration as mandatory